### PR TITLE
ASC-321 Record Test Case UUID Mark

### DIFF
--- a/pytest_rpc.py
+++ b/pytest_rpc.py
@@ -25,9 +25,32 @@ ENV_VARS = ['JENKINS_CONSOLE_LOG_URL',
 # ======================================================================================================================
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtestloop(session):
+    """Add XML properties group to the 'testsuite' element that captures the values for specified environment variables.
+
+    Args:
+        session (_pytest.main.Session): The pytest session object
+    """
+
     if session.config.pluginmanager.hasplugin('junitxml'):
             junit_xml_config = getattr(session.config, '_xml', None)
 
             if junit_xml_config:
                 for env_var in ENV_VARS:
                     junit_xml_config.add_global_property(env_var, os.getenv(env_var, 'Unknown'))
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(session, config, items):
+    """Add XML properties group to each 'testcase' element that captures the UUID for the pytest mark 'test_id'.
+
+    Args:
+        session (_pytest.main.Session): The pytest session object.
+        config (_pytest.config.Config): The pytest config object.
+        items (list(_pytest.nodes.Item)): List of item objects.
+    """
+
+    for item in items:
+        marker = item.get_marker('test_id')
+        if marker is not None:
+            test_id = marker.args[0]
+            item.user_properties.append(('test_id', test_id))

--- a/pytest_rpc.py
+++ b/pytest_rpc.py
@@ -39,13 +39,10 @@ def pytest_runtestloop(session):
                     junit_xml_config.add_global_property(env_var, os.getenv(env_var, 'Unknown'))
 
 
-@pytest.hookimpl(trylast=True)
-def pytest_collection_modifyitems(session, config, items):
+def pytest_collection_modifyitems(items):
     """Add XML properties group to each 'testcase' element that captures the UUID for the pytest mark 'test_id'.
 
     Args:
-        session (_pytest.main.Session): The pytest session object.
-        config (_pytest.config.Config): The pytest config object.
         items (list(_pytest.nodes.Item)): List of item objects.
     """
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-rpc',
-    version='0.1.0',
+    version='0.2.0',
     author='rcbops',
     author_email='rcb-deploy@lists.rackspace.com',
     maintainer='rcbops',
@@ -23,7 +23,7 @@ setup(
     description='Extend py.test for RPC OpenStack testing.',
     long_description=read('README.rst'),
     py_modules=['pytest_rpc'],
-    install_requires=['pytest>=3.1.1'],
+    install_requires=['pytest>=3.5.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Pytest',

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -91,7 +91,7 @@ class TestTestSuiteXMLProperties(object):
     """Test cases for the 'pytest_runtestloop' hook function for collecting environment variables"""
 
     def test_no_env_vars_set(self, testdir):
-        """Make sure that pytest accepts our fixture without setting any environment variables."""
+        """Verify that pytest accepts our fixture without setting any environment variables."""
 
         # Setup
         testdir.makepyfile("""
@@ -110,7 +110,7 @@ class TestTestSuiteXMLProperties(object):
             dom.find_nth_by_tag('property', i).assert_attr(name=ENV_VARS[i], value='Unknown')
 
     def test_env_vars_set(self, testdir):
-        """Make sure that pytest accepts our fixture with all relevant environment variables set."""
+        """Verify that pytest accepts our fixture with all relevant environment variables set."""
 
         # Setup
         testdir.makepyfile("""
@@ -136,7 +136,7 @@ class TestTestCaseXMLProperties(object):
     """Test cases for the 'pytest_collection_modifyitems' hook function for recording the UUID for test cases."""
 
     def test_uuid_mark_present(self, testdir):
-        """Make sure that pytest accepts our fixture without setting any environment variables."""
+        """Verify that 'test_id' property element is present when a test is decorated with a UUID mark."""
 
         # Expect
         test_id = '123e4567-e89b-12d3-a456-426655440000'
@@ -158,3 +158,83 @@ class TestTestCaseXMLProperties(object):
 
         test_case.assert_attr(name=test_name)
         test_case.find_first_by_tag('property').assert_attr(name='test_id', value=test_id)
+
+    def test_multiple_uuid_marks(self, testdir):
+        """Verify that 'test_id' property element is present when a test is decorated with multiple UUID marks.
+        The plug-in will choose the bottom-most decorator for the 'test_id'. Note: we DO NOT want to cause the test
+        run to fail in this scenario.
+        """
+
+        # Expect
+        test_id1 = 'first'
+        test_id2 = 'second'
+        test_name = 'test_uuid'
+
+        # Setup
+        testdir.makepyfile("""
+                    import pytest
+                    @pytest.mark.test_id('{}')
+                    @pytest.mark.test_id('{}')
+                    def {}():
+                        pass
+        """.format(test_id1, test_id2, test_name))
+
+        result, dom = runandparse(testdir)
+        test_case = dom.find_first_by_tag('testcase')
+
+        # Test
+        assert result.ret == 0
+
+        test_case.assert_attr(name=test_name)
+        test_case.find_first_by_tag('property').assert_attr(name='test_id', value=test_id2)
+
+    def test_multiple_test_cases_with_uuid_mark_present(self, testdir):
+        """Verify that 'test_id' property element is present when multiple tests are decorated with a UUID mark."""
+
+        # Expect
+        test_ids = ['first', 'second']
+        test_names = ['test_uuid1', 'test_uuid2']
+
+        # Setup
+        testdir.makepyfile("""
+                    import pytest
+                    @pytest.mark.test_id('{}')
+                    def {}():
+                        pass
+
+                    @pytest.mark.test_id('{}')
+                    def {}():
+                        pass
+        """.format(test_ids[0], test_names[0], test_ids[1], test_names[1]))
+
+        result, dom = runandparse(testdir)
+        test_cases = dom.find_by_tag('testcase')
+
+        # Test
+        assert result.ret == 0
+
+        for i in range(len(test_cases)):
+            test_cases[i].assert_attr(name=test_names[i])
+            test_cases[i].find_first_by_tag('property').assert_attr(name='test_id', value=test_ids[i])
+
+    def test_missing_uuid_marks(self, testdir):
+        """Verify that 'test_id' property element is absent when a test is NOT decorated with a UUID mark."""
+
+        # Expect
+        test_name = 'test_no_uuid'
+
+        # Setup
+        testdir.makepyfile("""
+                    import pytest
+                    def {}():
+                        pass
+        """.format(test_name))
+
+        result, dom = runandparse(testdir)
+        test_case = dom.find_first_by_tag('testcase')
+
+        # Test
+        assert result.ret == 0
+
+        test_case.assert_attr(name=test_name)
+        assert test_case.find_first_by_tag('property') is None


### PR DESCRIPTION
Update the plug-in to capture the UUID specified by the "test_id" pytest
mark.