### PR TITLE
ASC-349 Include Build Information in JUnitXML

### DIFF
--- a/pytest_rpc.py
+++ b/pytest_rpc.py
@@ -9,15 +9,18 @@ import pytest
 # ======================================================================================================================
 # Globals
 # ======================================================================================================================
-ENV_VARS = ['JENKINS_CONSOLE_LOG_URL',
-            'SCENARIO',
-            'ACTION',
-            'IMAGE',
+ENV_VARS = ['BUILD_URL',
+            'BUILD_NUMBER',
+            'RE_JOB_ACTION',
+            'RE_JOB_IMAGE',
+            'RE_JOB_SCENARIO',
+            'RE_JOB_BRANCH',
+            'RPC_RELEASE',
+            'RPC_PRODUCT_RELEASE',
             'OS_ARTIFACT_SHA',
             'PYTHON_ARTIFACT_SHA',
             'APT_ARTIFACT_SHA',
-            'GIT_REPO',
-            'GIT_BRANCH']
+            'REPO_URL']
 
 
 # ======================================================================================================================

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-rpc',
-    version='0.2.0',
+    version='0.3.0',
     author='rcbops',
     author_email='rcb-deploy@lists.rackspace.com',
     maintainer='rcbops',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,1 @@
-pytest_plugins = 'pytester'
+pytest_plugins = ['pytester']

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,16 @@ envlist = py27,py35,py36,flake8
 skip_missing_interpreters = true
 
 [testenv]
-deps = pytest
-commands = py.test {posargs:tests}
+setenv =
+    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements.txt
+; If you want to make tox run the tests with the same versions, create a
+; requirements.txt with the pinned versions and uncomment the following line:
+;     -r{toxinidir}/requirements.txt
+commands =
+    pip install -U pip
+    py.test --basetemp={envtmpdir}
 
 [testenv:flake8]
 skip_install = true
@@ -13,4 +21,4 @@ deps = flake8
 commands = flake8 pytest_rpc.py setup.py tests
 
 [flake8]
-max-line-length = 119
+max-line-length = 120


### PR DESCRIPTION
Add the build number and build URL to the JUnitXML testsuite properties.
Also, I ended up fixing some minor issues with the tox.ini file along
with other fixups.