### PR TITLE
ASC-428 Capture Jira Ticket in JUnitXML

### DIFF
--- a/pytest_rpc/__init__.py
+++ b/pytest_rpc/__init__.py
@@ -32,7 +32,25 @@ ENV_VARS = ['BUILD_URL',
 
 
 # ======================================================================================================================
-# Functions
+# Functions: Private
+# ======================================================================================================================
+def _capture_marks(items, marks):
+    """Add XML properties group to each 'testcase' element that captures the specified marks.
+
+    Args:
+        items (list(_pytest.nodes.Item)): List of item objects.
+        marks (list(str)): A list of marks to capture and record in JUnitXML for each 'testcase'.
+    """
+
+    for item in items:
+        for mark in marks:
+            marker = item.get_marker(mark)
+            if marker is not None:
+                item.user_properties.append((mark, marker.args[0]))
+
+
+# ======================================================================================================================
+# Functions: Public
 # ======================================================================================================================
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtestloop(session):
@@ -51,17 +69,13 @@ def pytest_runtestloop(session):
 
 
 def pytest_collection_modifyitems(items):
-    """Add XML properties group to each 'testcase' element that captures the UUID for the pytest mark 'test_id'.
+    """Called after collection has been performed, may filter or re-order the items in-place.
 
     Args:
         items (list(_pytest.nodes.Item)): List of item objects.
     """
 
-    for item in items:
-        marker = item.get_marker('test_id')
-        if marker is not None:
-            test_id = marker.args[0]
-            item.user_properties.append(('test_id', test_id))
+    _capture_marks(items, ('test_id', 'jira'))
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/pytest_rpc/data/molecule_junit.xsd
+++ b/pytest_rpc/data/molecule_junit.xsd
@@ -24,6 +24,7 @@
     <xs:simpleType name="validTestcaseProperty">
         <xs:restriction base="xs:normalizedString">
             <xs:enumeration value="test_id" />
+            <xs:enumeration value="jira" />
             <xs:enumeration value="start_time" />
             <xs:enumeration value="end_time" />
         </xs:restriction>
@@ -59,9 +60,9 @@
         <xs:attribute name="value" type="xs:normalizedString" use="required" />
     </xs:complexType>
 
-    <!--Testcase properties element containing exactly 3 sub-elements.-->
+    <!--Testcase properties element containing exactly 4 sub-elements.-->
     <xs:complexType name="testCasePropertiesType">
-        <xs:sequence minOccurs="3" maxOccurs="3">
+        <xs:sequence minOccurs="4" maxOccurs="4">
             <xs:element name="property" type="testCasePropertyType" />
         </xs:sequence>
     </xs:complexType>


### PR DESCRIPTION
Record the associated Jira ticket ID specified with the 'jira' pytest mark
decorator.