### PR TITLE
ASC-234 Add helper for getting RPC version

### DIFF
--- a/pytest_rpc/helpers.py
+++ b/pytest_rpc/helpers.py
@@ -1,0 +1,35 @@
+import sh
+
+
+def get_git_branch():
+    """Retrieve current git branch name of calling repo
+
+    Returns:
+        str: current git branch name
+    """
+
+    git = sh.git.bake(_cwd='.')
+    return git('rev-parse', '--abbrev-ref', 'HEAD')
+
+
+def get_osa_version_tuple():
+    """Get tuple of OpenStack version (code_name, major_version) as raw
+    strings.
+
+    This data is based on the git branch of the test suite being executed
+    Returns:
+        tuple: (code_name, major_version) as raw strings of OpenStack version
+    """
+
+    cur_branch = get_git_branch()
+
+    if cur_branch in ['newton', 'newton-rc']:
+        return (r'Newton', r'14')
+    elif cur_branch in ['pike', 'pike-rc']:
+        return (r'Pike', r'16')
+    elif cur_branch in ['queens', 'queens-rc']:
+        return (r'Queens', r'17')
+    elif cur_branch == 'master-rc':
+        return (r'Queens', r'17')
+    else:
+        return (r'\w+', r'\d+')

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ setuptools
 ipython
 bumpversion
 twine
+sh

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 python_requirements = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-requirements = ['pytest>=3.5.0', 'setuptools']
+requirements = ['pytest>=3.5.0', 'setuptools', 'sh']
 packages = ['pytest_rpc']
 entry_points = {
     'pytest11': [

--- a/tests/helpers/test_get_osa_version_tuple.py
+++ b/tests/helpers/test_get_osa_version_tuple.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+import pytest_rpc.helpers
+
+"""Test cases for the 'get_osa_version_tuple' helper function."""
+
+
+def test_newton_version(monkeypatch):
+    """Verify osa versions for newton branch"""
+    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'newton')
+    assert pytest_rpc.helpers.get_osa_version_tuple() == (r'Newton', r'14')
+
+
+def test_newton_rc_version(monkeypatch):
+    """Verify osa versions for newton-rc branch"""
+    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'newton-rc')
+    assert pytest_rpc.helpers.get_osa_version_tuple() == (r'Newton', r'14')
+
+
+def test_pike_version(monkeypatch):
+    """Verify osa versions for pike branch"""
+    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'pike')
+    assert pytest_rpc.helpers.get_osa_version_tuple() == (r'Pike', r'16')
+
+
+def test_pike_rc_version(monkeypatch):
+    """Verify osa versions for pike-rc branch"""
+    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'pike-rc')
+    assert pytest_rpc.helpers.get_osa_version_tuple() == (r'Pike', r'16')
+
+
+def test_queens_version(monkeypatch):
+    """Verify osa versions for queens branch"""
+    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'queens')
+    assert pytest_rpc.helpers.get_osa_version_tuple() == (r'Queens', r'17')
+
+
+def test_queens_rc_version(monkeypatch):
+    """Verify osa versions for queens-rc branch"""
+    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'queens-rc')
+    assert pytest_rpc.helpers.get_osa_version_tuple() == (r'Queens', r'17')
+
+
+def test_master_version(monkeypatch):
+    """Verify osa versions for master branch"""
+    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'master')
+    assert pytest_rpc.helpers.get_osa_version_tuple() == (r'\w+', r'\d+')


### PR DESCRIPTION
This commit adds the `get_osa_version_re_tuple` helper method to
`pytest-rpc` for use in molecule pytest test cases.