### PR TITLE
(maint) added logs for get_expected_value method

### DIFF
--- a/pytest_rpc/helpers.py
+++ b/pytest_rpc/helpers.py
@@ -203,12 +203,8 @@ def get_expected_value(service_type, service_name, key, expected_value,
             else:
                 sleep(6)
         else:
-            # Printing out logs if failed
-            print("\n===== Debug: get_expected_value logs =====")
-            print("\ncmd=" + cmd)
-            print("\nOutput:" + result)
-            print("\n===== End of get_expected_value logs =====")
-            return False
+            print("\n Key not found: {}\n".format(key))
+            break
 
     # Printing out logs if failed
     print("\n===== Debug: get_expected_value logs =====")

--- a/pytest_rpc/helpers.py
+++ b/pytest_rpc/helpers.py
@@ -203,8 +203,18 @@ def get_expected_value(service_type, service_name, key, expected_value,
             else:
                 sleep(6)
         else:
+            # Printing out logs if failed
+            print("\n===== Debug: get_expected_value logs =====")
+            print("\ncmd=" + cmd)
+            print("\nOutput:" + result)
+            print("\n===== End of get_expected_value logs =====")
             return False
 
+    # Printing out logs if failed
+    print("\n===== Debug: get_expected_value logs =====")
+    print("\ncmd=" + cmd)
+    print("\nOutput:" + result)
+    print("\n===== End of get_expected_value logs =====")
     return False
 
 


### PR DESCRIPTION
Prior to this PR, if get_expected_value method returns False, the test that uses this method simply fails without any debug logs, hence it is very hard to trace why it fails.

This PR addes debugs logs printing the output of `openstack show` command so it will be easier to see what the return values are.