### PR TITLE
ASC-706 Trap ValueError in get_expected_value

### DIFF
--- a/pytest_rpc/helpers.py
+++ b/pytest_rpc/helpers.py
@@ -191,17 +191,22 @@ def get_expected_value(service_type, service_name, key, expected_value,
         boolean: Whether the expected value was found or not.
     """
     for i in range(0, retries):
+        sleep(6)
         cmd = "{} openstack {} show \'{}\' -f json'".format(utility_container,
                                                             service_type,
                                                             service_name)
         output = run_on_host.run(cmd)
-        result = json.loads(output.stdout)
+        try:
+            result = json.loads(output.stdout)
+        except ValueError as e:
+            result = str(e)
+            continue
 
         if key in result:
             if result[key] == expected_value:
                 return True
             else:
-                sleep(6)
+                continue
         else:
             print("\n Key not found: {}\n".format(key))
             break

--- a/tests/helpers/test_get_expected_value.py
+++ b/tests/helpers/test_get_expected_value.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+import pytest_rpc.helpers
+
+"""Test cases for the 'get_expected_value' helper function."""
+
+
+def test_get_expected_value_invalid_json(mocker):
+    """Verify get_expected_value returns False when invalid JSON is obtained
+    via OpenStack query."""
+    myout = mocker.MagicMock(stdout='')
+    myhost = mocker.MagicMock()
+    myhost.run.return_value = myout
+    assert not pytest_rpc.helpers.get_expected_value('server', 'bar', 'key',
+                                                     'expected_value', myhost,
+                                                     1)


### PR DESCRIPTION
This commit traps the ValueError in the `get_expected_value` helper in
the event that the OpenStack query returns invalid JSON.