### PR TITLE
ASC-705 Add unit tests for create_instance

### DIFF
--- a/pytest_rpc/helpers.py
+++ b/pytest_rpc/helpers.py
@@ -252,6 +252,9 @@ def create_instance(data, run_on_host):
                     }
         run_on_host (testinfra.host.Host): A hostname where the command is being executed.
 
+    Raises:
+        AssertionError: If operation is unsuccessful.
+
     Example:
     `openstack server create --image <image_id> flavor <flavor> --nic <net-id=network_id> server/instance_name`
     `openstack server create --snapshot <snapshot_id> flavor <flavor> --nic <net-id=network_id> server/instance_name`

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ ipython
 bumpversion
 twine
 sh
+testinfra

--- a/tests/helpers/test_create_instance.py
+++ b/tests/helpers/test_create_instance.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+import pytest_rpc.helpers
+import pytest
+import json
+import testinfra.backend.base
+import testinfra.host
+
+"""Test cases for the 'create_instance' helper function."""
+
+
+def test_success(mocker):
+    """Verify create_instance completes without raising an error and returns
+    None when the OpenStack command returns an exit code of '0'.
+
+    relies on mocked objects from testinfra
+    """
+
+    fake_backend = mocker.Mock(spec=testinfra.backend.base.BaseBackend)
+    myhost = testinfra.host.Host(fake_backend)
+    cr = mocker.Mock(spec=testinfra.backend.base.CommandResult)
+    mocker.patch('testinfra.host.Host.run', return_value=cr)
+
+    server = {'id': 'foo', 'name': 'myserver'}
+    cr.rc = 0
+    cr.stdout = json.dumps(server)
+
+    data = {
+        "instance_name": 'instance_name',
+        "from_source": 'image',
+        "source_name": 'image_name',
+        "flavor": 'flavor',
+        "network_name": 'network',
+    }
+
+    assert not pytest_rpc.helpers.create_instance(data, myhost)
+
+
+def test_failure(mocker):
+    """Verify create_instance raises an error when the OpenStack command
+    returns an exit code of '2'.
+
+    relies on mocked objects from testinfra
+    """
+    """Verify create_instance raises and AssertionError when server instance
+    has failed to be successfully created."""
+
+    fake_backend = mocker.Mock(spec=testinfra.backend.base.BaseBackend)
+    myhost = testinfra.host.Host(fake_backend)
+    cr = mocker.Mock(spec=testinfra.backend.base.CommandResult)
+    mocker.patch('testinfra.host.Host.run', return_value=cr)
+
+    server = {'id': 'foo', 'name': 'myserver'}
+    cr.rc = 2
+    cr.stdout = json.dumps(server)
+
+    data = {
+        "instance_name": 'instance_name',
+        "from_source": 'image',
+        "source_name": 'image_name',
+        "flavor": 'flavor',
+        "network_name": 'network',
+    }
+
+    with pytest.raises(AssertionError):
+        pytest_rpc.helpers.create_instance(data, myhost)

--- a/tests/helpers/test_create_instance.py
+++ b/tests/helpers/test_create_instance.py
@@ -9,8 +9,8 @@ import testinfra.host
 
 
 def test_success(mocker):
-    """Verify create_instance completes without raising an error and returns
-    None when the OpenStack command returns an exit code of '0'.
+    """Verify create_instance returns None when the OpenStack command returns
+    an exit code of '0'.
 
     relies on mocked objects from testinfra
     """
@@ -36,13 +36,11 @@ def test_success(mocker):
 
 
 def test_failure(mocker):
-    """Verify create_instance raises an error when the OpenStack command
-    returns an exit code of '2'.
+    """Verify create_instance raises an AssertionError when the server instance
+    has failed to be successfully created.
 
     relies on mocked objects from testinfra
     """
-    """Verify create_instance raises and AssertionError when server instance
-    has failed to be successfully created."""
 
     fake_backend = mocker.Mock(spec=testinfra.backend.base.BaseBackend)
     myhost = testinfra.host.Host(fake_backend)


### PR DESCRIPTION
This commit adds unit tests for the `create_instance` helper.