### PR TITLE
MAINT - Fix data gather get_resource_list_by_name

### DIFF
--- a/pytest_rpc/helpers.py
+++ b/pytest_rpc/helpers.py
@@ -125,7 +125,7 @@ def get_resource_list_by_name(name, run_on_host):
     """
 
     cmd = (". ~/openrc ; "
-           "openstack {} list".format(name))
+           "openstack {} list -f json".format(name))
     output = run_on_container(cmd, 'utility', run_on_host)
     try:
         result = json.loads(output.stdout)

--- a/tests/helpers/test_get_resource_list_by_name.py
+++ b/tests/helpers/test_get_resource_list_by_name.py
@@ -19,3 +19,35 @@ def test_get_resource_list_by_name(mocker):
     mocker.patch('testinfra.host.Host.run', return_value=command_result)
 
     assert type(pytest_rpc.helpers.get_resource_list_by_name('server', myhost)) == list
+
+
+def test_get_resource_list_by_name_with_data(mocker):
+    """Verify get_resource_list_by_name returns a valid json list."""
+
+    data = """[{
+               "Status": "available",
+               "Size": 1,
+               "Attached to": "",
+               "ID": "affd0981-bf11-4472-989c-03c7837a52fb",
+               "Name": "delme"
+             },
+             {
+               "Status": "available",
+               "Size": 1,
+               "Attached to": "",
+               "ID": "b93155f7-770a-4a3a-baef-d8f466a2aa6e",
+               "Name": "post-deploy-volume"
+             }]"""
+
+    fake_backend = mocker.Mock(spec=testinfra.backend.base.BaseBackend)
+    myhost = testinfra.host.Host(fake_backend)
+    command_result = mocker.Mock(spec=testinfra.backend.base.CommandResult)
+
+    command_result.rc = 0
+    command_result.stdout = json.dumps(json.loads(data))
+    mocker.patch('testinfra.host.Host.run', return_value=command_result)
+
+    volumes = pytest_rpc.helpers.get_resource_list_by_name('volume', myhost)
+    assert volumes
+    assert '-f json' in myhost.run.call_args[0][0]
+    assert 'delme' in [x['Name'] for x in volumes]


### PR DESCRIPTION
This commit fixes a bug in the `get_resource_list_by_name` helper.

The helper proclaims that it will gather dictionary data for the given
resource type. However, the underlying call to the `openstack` cli does
not specify that JSON data should be returned. So, the helper will
always return an empty list even when there is valid data.

This bug is corrected and a unit test has been added to prevent this
error from regressing in the future.