### PR TITLE
ASC-856 Update get_osa_version helper

### DIFF
--- a/pytest_rpc/helpers.py
+++ b/pytest_rpc/helpers.py
@@ -1,42 +1,33 @@
-import sh
 import json
 import uuid
 import re
 from time import sleep
 
 
-def get_git_branch():
-    """Retrieve current git branch name of calling repo
-
-    Returns:
-        str: current git branch name
-    """
-
-    git = sh.git.bake(_cwd='.')
-    return git('rev-parse', '--abbrev-ref', 'HEAD')
-
-
-def get_osa_version():
+def get_osa_version(branch):
     """Get OpenStack version (code_name, major_version)
 
     This data is based on the git branch of the test suite being executed
 
+    Arge:
+        branch (str): The rpc-openstack branch to query for.
+
     Returns:
-        tuple of (str, str): (code_name, major_version) OpenStack version
+        tuple of (str, str): (code_name, major_version) OpenStack version.
+                             These strings will be empty if the branch is
+                             unknown.
     """
 
-    cur_branch = get_git_branch()
-
-    if cur_branch in ['newton', 'newton-rc']:
-        return (r'Newton', r'14')
-    elif cur_branch in ['pike', 'pike-rc']:
-        return (r'Pike', r'16')
-    elif cur_branch in ['queens', 'queens-rc']:
-        return (r'Queens', r'17')
-    elif cur_branch in ['rocky', 'rocky-rc']:
-        return (r'Rocky', r'18')
+    if branch in ['newton', 'newton-rc']:
+        return ('Newton', '14')
+    elif branch in ['pike', 'pike-rc']:
+        return ('Pike', '16')
+    elif branch in ['queens', 'queens-rc']:
+        return ('Queens', '17')
+    elif branch in ['rocky', 'rocky-rc']:
+        return ('Rocky', '18')
     else:
-        return (r'\w+', r'\w+')
+        return ('', '')
 
 
 def get_id_by_name(service_type, service_name, run_on_host):

--- a/tests/helpers/test_get_osa_version.py
+++ b/tests/helpers/test_get_osa_version.py
@@ -4,43 +4,46 @@ import pytest_rpc.helpers
 """Test cases for the 'get_osa_version' helper function."""
 
 
-def test_newton_version(monkeypatch):
+def test_newton_version():
     """Verify osa versions for newton branch"""
-    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'newton')
-    assert pytest_rpc.helpers.get_osa_version() == (r'Newton', r'14')
+    assert pytest_rpc.helpers.get_osa_version('newton') == ('Newton', '14')
 
 
-def test_newton_rc_version(monkeypatch):
+def test_newton_rc_version():
     """Verify osa versions for newton-rc branch"""
-    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'newton-rc')
-    assert pytest_rpc.helpers.get_osa_version() == (r'Newton', r'14')
+    assert pytest_rpc.helpers.get_osa_version('newton-rc') == ('Newton', '14')
 
 
-def test_pike_version(monkeypatch):
+def test_pike_version():
     """Verify osa versions for pike branch"""
-    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'pike')
-    assert pytest_rpc.helpers.get_osa_version() == (r'Pike', r'16')
+    assert pytest_rpc.helpers.get_osa_version('pike') == ('Pike', '16')
 
 
-def test_pike_rc_version(monkeypatch):
+def test_pike_rc_version():
     """Verify osa versions for pike-rc branch"""
-    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'pike-rc')
-    assert pytest_rpc.helpers.get_osa_version() == (r'Pike', r'16')
+    assert pytest_rpc.helpers.get_osa_version('pike-rc') == ('Pike', '16')
 
 
-def test_queens_version(monkeypatch):
+def test_queens_version():
     """Verify osa versions for queens branch"""
-    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'queens')
-    assert pytest_rpc.helpers.get_osa_version() == (r'Queens', r'17')
+    assert pytest_rpc.helpers.get_osa_version('queens') == ('Queens', '17')
 
 
-def test_queens_rc_version(monkeypatch):
+def test_queens_rc_version():
     """Verify osa versions for queens-rc branch"""
-    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'queens-rc')
-    assert pytest_rpc.helpers.get_osa_version() == (r'Queens', r'17')
+    assert pytest_rpc.helpers.get_osa_version('queens-rc') == ('Queens', '17')
 
 
-def test_master_version(monkeypatch):
+def test_rocky_version():
+    """Verify osa versions for rocky branch"""
+    assert pytest_rpc.helpers.get_osa_version('rocky-rc') == ('Rocky', '18')
+
+
+def test_rocky_rc_version():
+    """Verify osa versions for rocky-rc branch"""
+    assert pytest_rpc.helpers.get_osa_version('rocky-rc') == ('Rocky', '18')
+
+
+def test_master_version():
     """Verify osa versions for master branch"""
-    monkeypatch.setattr(pytest_rpc.helpers, 'get_git_branch', lambda: 'master')
-    assert pytest_rpc.helpers.get_osa_version() == (r'\w+', r'\w+')
+    assert pytest_rpc.helpers.get_osa_version('master') == ('', '')


### PR DESCRIPTION
This commit updates the `get_osa_version` helper to take a string as an
argument. It now also returns empty strings when an unmapped value is
given.

Since the `get_git_branch` helper is no longer used and provides no
value, it has been deleted.