### PR TITLE
ASC-889 Refactor Helpers (WIP)

### DIFF
--- a/pytest_rpc/helpers.py
+++ b/pytest_rpc/helpers.py
@@ -1,93 +1,204 @@
+# -*- coding: utf-8 -*-
+
+# ==============================================================================
+# Imports
+# ==============================================================================
+import re
 import json
 import uuid
-import re
 from time import sleep
 
 
-def get_osa_version(branch):
-    """Get OpenStack version (code_name, major_version)
-
-    This data is based on the git branch of the test suite being executed
-
-    Arge:
-        branch (str): The rpc-openstack branch to query for.
-
-    Returns:
-        tuple of (str, str): (code_name, major_version) OpenStack version.
-                             These strings will be empty if the branch is
-                             unknown.
-    """
-
-    if branch in ['newton', 'newton-rc']:
-        return 'Newton', '14'
-    elif branch in ['pike', 'pike-rc']:
-        return 'Pike', '16'
-    elif branch in ['queens', 'queens-rc']:
-        return 'Queens', '17'
-    elif branch in ['rocky', 'rocky-rc']:
-        return 'Rocky', '18'
-    else:
-        return '', ''
-
-
-def get_id_by_name(service_type, service_name, run_on_host):
-    """Get the id associated with name
+# ==============================================================================
+# Private Functions
+# ==============================================================================
+def _delete_it(run_on_host,
+               resource_type,
+               resource_id,
+               retries=10,
+               addl_flags=''):
+    """Delete an OpenStack resource.
 
     Args:
-        service_type (str): The OpenStack object type to query for.
-        service_name (str): The name of the OpenStack object instance to query
-                            for.
         run_on_host (testinfra.Host): Testinfra host object to execute the
-                                      action on.
+            action upon.
+        resource_type (str): The OpenStack object type to query for.
+        resource_id (uuid.UUID): The ID of the OpenStack object to query for.
+        retries (int): The maximum number of retry attempts.
+        addl_flags (str): Additional flags to pass to the OpenStack command.
 
     Returns:
-        str: Id of Openstack object instance. None if result not found.
-    """
-
-    resources = get_resource_list_by_name(service_type, run_on_host)
-    if not resources:
-        return
-
-    try:
-        matches = [x for x in resources if x['Name'] == service_name]
-    except (KeyError, TypeError):
-        try:
-            matches = [x for x in resources if x['Display Name']
-                       == service_name]
-        except (KeyError, TypeError):
-            return
-
-    if not matches:
-        return
-
-    result = matches[0]
-
-    if 'ID' in result.keys():
-        return result['ID']
-    else:
-        return
-
-
-def create_bootable_volume(data, run_on_host):
-    """Create a bootable volume using a json file
-
-    Args:
-        data (dict): Dictionary in the following format:
-                     { 'volume': { 'size': '',
-                                   'imageref': '',
-                                   'name': '',
-                                   'zone': '',
-                                 }
-                     }
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-                                      action on.
-
-    Returns:
-        str: The id of the created resource
+        bool: True if the resource was successfully deleted, otherwise False.
 
     Raises:
-        AssertionError: If failed to create the resource
+        AssertionError: Failed to delete resource!
     """
+
+    __tracebackhide__ = True
+
+    sleep_timeout = 2
+    cmd = (". ~/openrc ; "
+           "openstack {} delete "
+           "{} "
+           "{}".format(resource_type, addl_flags, resource_id))
+    assert_msg = ("Failed to delete resource type '{}' with given ID '{}'"
+                  "!".format(resource_type, resource_id))
+
+    assert run_on_container(run_on_host, cmd, 'utility').rc == 0, assert_msg
+
+    for i in range(0, retries):
+        try:
+            assert_resource_exists_by_id(run_on_host,
+                                         resource_type,
+                                         resource_id)
+        except AssertionError:
+            return True     # If assertion fails then the resource is deleted.
+
+        sleep(sleep_timeout)
+
+    return False
+
+
+# ==============================================================================
+# Public Functions
+# ==============================================================================
+def assert_resource_attribute_value(run_on_host,
+                                    resource_type,
+                                    resource_id,
+                                    attribute_name,
+                                    expected_value,
+                                    retries=10,
+                                    case_insensitive=True):
+    """Assert that an OpenStack resource attribute has expected value.
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action on.
+        resource_type (str): The OpenStack resource type to query for.
+        resource_id (uuid.UUID): The name of the OpenStack resource ID to
+            query for.
+        attribute_name (str): The OpenStack resource attribute to inspect for
+            expected value.
+        expected_value (str): The expected value for the OpenStack resource
+            attribute.
+        retries (int): The maximum number of retry attempts.
+        case_insensitive (bool): Flag for controlling whether to match case
+            sensitive or not for 'expected_value'.
+
+    Raises:
+        AssertionError: No resources of the given type found!
+    """
+
+    __tracebackhide__ = True
+
+    sleep_timeout = 6
+    resource = {}
+    expectation_met = False
+
+    for i in range(0, retries):
+        try:
+            resource = get_resource_by_id(run_on_host,
+                                          resource_type,
+                                          resource_id)
+        except RuntimeError as e:
+            raise AssertionError(str(e))
+
+        if attribute_name not in resource:
+            raise AssertionError(
+                "Attribute '{}' for resource type '{}'"
+                "with ID '{}' does not "
+                "exist!".format(attribute_name, resource_type, resource_id)
+            )
+
+        if resource[attribute_name] == expected_value:
+            expectation_met = True
+        elif resource[attribute_name].lower() == expected_value \
+                and case_insensitive:
+            expectation_met = True
+        else:
+            continue
+
+        sleep(sleep_timeout)
+
+    if not expectation_met:
+        raise AssertionError(
+            "Actual attribute value does not match "
+            "expected for resource type '{}' with ID '{}'!" 
+            "Expected: '{}' Actual: '{}'".format(resource_type,
+                                                 str(resource_id),
+                                                 expected_value,
+                                                 resource[attribute_name])
+        )
+
+
+def assert_resource_exists_by_id(run_on_host, resource_type, resource_id):
+    """Assert that a given resource exists within the OpenStack infrastructure.
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action upon.
+        resource_type (str): The OpenStack resource type to query for.
+        resource_id (uuid.UUID): The name of the OpenStack object to query for.
+
+    Returns:
+        list: OpenStack object instances parsed from JSON. [{str:obj}]
+
+    Raises:
+        AssertionError: No resources of the given type found!
+    """
+
+    __tracebackhide__ = True
+
+    try:
+        get_resource_by_id(run_on_host, resource_type, resource_id)
+    except RuntimeError as e:
+        raise AssertionError(str(e))
+
+
+def assert_resource_exists_by_name(run_on_host, resource_type, resource_name):
+    """Assert that a given resource exists within the OpenStack infrastructure.
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action upon.
+        resource_type (str): The OpenStack resource type to query for.
+        resource_name (str): The name of the OpenStack object to query for.
+
+    Returns:
+        list: OpenStack object instances parsed from JSON. [{str:obj}]
+
+    Raises:
+        AssertionError: No resources of the given type found!
+    """
+
+    __tracebackhide__ = True
+
+    assert_msg = ("Resource type '{}' with name '{}' was "
+                  "not found!".format(resource_type,  resource_name))
+
+    assert (get_resources_by_name(run_on_host, resource_type, resource_name),
+            assert_msg)
+
+
+def create_bootable_volume(run_on_host, size, imageref, name, zone):
+    """Create a bootable volume using a json file.
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action upon.
+        size (int): Size of the volume.
+        imageref (str): Reference ID for the image to apply to the new volume.
+        name (str): Human readable name to apply to the volume.
+        zone (str): The zone to apply to the new volume.
+
+    Returns:
+        uuid.UUID: The ID of the created resource.
+
+    Raises:
+        AssertionError: Failed to create bootable volume!
+    """
+
+    __tracebackhide__ = True
 
     cmd = (". ~/openrc ; "
            "openstack volume create "
@@ -95,89 +206,195 @@ def create_bootable_volume(data, run_on_host):
            "--size {} "
            "--image {} "
            "--availability-zone {} "
-           "--bootable {}".format(data['volume']['size'],
-                                  data['volume']['imageref'],
-                                  data['volume']['zone'],
-                                  data['volume']['name']))
+           "--bootable {}".format(size, imageref, zone, name))
 
-    output = run_on_container(cmd, 'utility', run_on_host)
+    output = run_on_container(run_on_host, cmd, 'utility')
+    assert_msg = 'Failed to create bootable volume!'
 
     try:
         result = json.loads(output.stdout)
     except ValueError:
         result = output.stdout
 
-    assert type(result) is dict
-    assert 'id' in result
+    assert type(result) is dict, assert_msg
+    assert 'id' in result, assert_msg
 
-    return result['id']
+    return uuid.UUID(result['id'])
 
 
-def get_resource_list_by_name(name, run_on_host):
-    """Get a list of OpenStack object instances of given type.
+# TODO: Should this also return the UUID of the resource?
+def create_floating_ip(run_on_host, network_resource_id):
+    """Create floating IP on a network
 
     Args:
-        name (str): The OpenStack object type to query for.
         run_on_host (testinfra.Host): Testinfra host object to execute the
-                                      action on.
+            action on.
+        network_resource_id (uuid.UUID): The name of the OpenStack network
+            object on which to create the floating IP.
 
     Returns:
-        list of dict: OpenStack object instances parsed from JSON
+        str: The newly created floating ip name
+
+    Raises:
+        AssertionError: Failed to create floating IP!
     """
 
-    cmd = (". ~/openrc ; "
-           "openstack {} list -f json".format(name))
-    output = run_on_container(cmd, 'utility', run_on_host)
+    __tracebackhide__ = True
+
+    cmd = (". ~/openrc ; openstack floating ip create "
+           "-f json {}".format(str(network_resource_id)))
+    key = 'floating_ip_address'
+    output = run_on_container(run_on_host, cmd, 'utility')
+    assert_msg = 'Failed to create floating IP!'
+
+    assert (output.rc == 0), assert_msg
+
     try:
         result = json.loads(output.stdout)
     except ValueError:
-        result = []
-    return result
+        result = output.stdout
+
+    assert type(result) is dict, assert_msg
+    assert key in result.keys(), assert_msg
+
+    return result[key]
 
 
-def delete_volume(volume_name, run_on_host, addl_flags=''):
+def create_instance(run_on_host,
+                    instance_name,
+                    image_source_name,
+                    image_name,
+                    flavor_name,
+                    network_name):
+    """Create an instance from source (a glance image or a snapshot)
+
+    Args:
+        run_on_host (testinfra.host.Host): A hostname where the command is being
+            executed.
+        instance_name (str): Human readable name of instance.
+        image_source_name (str): The OpenStack resource name of the image
+            source.
+        image_name (str): The OpenStack resource name of the image to use for
+            provisioning the instance.
+        flavor_name (str): The flavor to apply to the instance.
+        network_name (str): The network attached to the newly created instance.
+
+    Returns:
+        uuid.UUID: The ID of the newly created instance.
+
+    Raises:
+        AssertionError: Failed to create instance!
+
+    Example:
+        `openstack server create --image <image_id> flavor <flavor> \
+        --nic <net-id=network_id> server/instance_name` \
+        `openstack server create --snapshot <snapshot_id> flavor <flavor> \
+        --nic <net-id=network_id> server/instance_name`
+    """
+
+    __tracebackhide__ = True
+
+    source_id = get_id_by_name(run_on_host, image_source_name, image_name)
+    network_id = get_id_by_name(run_on_host, 'network', network_name)
+
+    cmd = (". ~/openrc ; "
+           "openstack server create "
+           "-f json "
+           "--{} {} "
+           "--flavor {} "
+           "--nic net-id={} {}".format(image_source_name,
+                                       str(source_id),
+                                       flavor_name,
+                                       str(network_id),
+                                       instance_name))
+
+    output = run_on_container(run_on_host, cmd, 'utility')
+    assert_msg = 'Failed to create instance!'
+
+    try:
+        result = json.loads(output.stdout)
+    except ValueError:
+        result = output.stdout
+
+    assert type(result) is dict, assert_msg
+    assert 'id' in result, assert_msg
+
+    return uuid.UUID(result['id'])
+
+
+def create_snapshot_from_instance(run_on_host, snapshot_name, instance_id):
+    """Create snapshot on an instance
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action on.
+        snapshot_name (str): The name of the newly created snapshot.
+        instance_id (uuid.UUID): The name of the OpenStack instance from which
+            the snapshot is created.
+
+    Returns:
+        uuid.UUID: The ID of the newly created snapshot.
+
+    Raises:
+        AssertionError: Failed to create snapshot!
+    """
+
+    __tracebackhide__ = True
+
+    cmd = (". ~/openrc ; "
+           "openstack server image create "
+           "-f json "
+           "--name {} {}".format(snapshot_name, instance_id))
+
+    output = run_on_container(run_on_host, cmd, 'utility')
+    assert_msg = 'Failed to create snapshot!'
+
+    try:
+        result = json.loads(output.stdout)
+    except ValueError:
+        result = output.stdout
+
+    assert type(result) is dict, assert_msg
+    assert 'id' in result, assert_msg
+
+    return uuid.UUID(result['id'])
+
+
+def delete_instance(run_on_host, instance_id):
+    """Delete OpenStack instance
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action on.
+        instance_id (uuid.UUID): The OpenStack resource ID of the instance to
+            delete.
+
+    Raises:
+        AssertionError: Failed to delete resource!
+    """
+
+    __tracebackhide__ = True
+
+    _delete_it(run_on_host, 'server', instance_id)
+
+
+def delete_volume(run_on_host, volume_id, addl_flags=''):
     """Delete OpenStack volume
 
     Args:
-        volume_name (str): OpenStack volume identifier (name or id).
         run_on_host (testinfra.Host): Testinfra host object to execute the
             action on.
+        volume_id (uuid.UUID): OpenStack volume identifier (name or id).
         addl_flags (str): Add additional flags to the call to OpenStack CLI
             when deleting a volume.
 
     Raises:
-        AssertionError: If operation unsuccessful.
+        AssertionError: Failed to delete resource!
     """
 
-    delete_it('volume', volume_name, run_on_host, addl_flags=addl_flags)
+    __tracebackhide__ = True
 
-
-def parse_table(ascii_table):
-    """Parse an OpenStack ascii table
-
-    Args:
-        ascii_table (str): OpenStack ascii table.
-
-    Returns:
-        list of str: Column headers from table.
-        list of str: Rows from table.
-    """
-    header = []
-    data = []
-    for line in filter(None, ascii_table.split('\n')):
-        if '-+-' in line:
-            continue
-        if not header:
-            header = list(filter(lambda x: x != '|', line.split()))
-            continue
-        data_row = []
-        splitted_line = list(filter(lambda x: x != '|', line.split()))
-        for i in range(len(splitted_line)):
-            data_row.append(splitted_line[i])
-        while len(data_row) < len(header):
-            data_row.append('')
-        data.append(data_row)
-    return header, data
+    _delete_it(run_on_host, 'volume', volume_id, addl_flags=addl_flags)
 
 
 def generate_random_string(string_length=10):
@@ -189,396 +406,167 @@ def generate_random_string(string_length=10):
     Returns:
         str: Random string of specified length (maximum of 32 characters)
     """
+
     random_str = str(uuid.uuid4())
     random_str = random_str.upper()
     random_str = random_str.replace("-", "")
+
     return random_str[0:string_length]  # Return the random_str string.
 
 
-def get_expected_value(resource_type,
-                       resource_name,
-                       key,
-                       expected_value,
-                       run_on_host,
-                       retries=10,
-                       case_insensitive=True):
-    """Getting an expected status after retries
+def get_id_by_name(run_on_host, resource_type, resource_name):
+    """Get the ID associated with resource name of the given resource type.
+
+    Note: If multiple resources of the same type share the same name then this
+    function will return the ID for the first resource name match.
 
     Args:
-        resource_type (str): The OpenStack object type to query for.
-        resource_name (str): The name of the OpenStack object instance to query
-            for.
-        key (str): The OpenStack object instance parameter to check against.
-        expected_value (str): The expected value for the given key.
         run_on_host (testinfra.Host): Testinfra host object to execute the
-            action on.
-        retries (int): The maximum number of retry attempts.
-        case_insensitive (bool): Flag for controlling whether to match case
-            sensitive or not for the 'expected_value'.
+            action upon.
+        resource_type (str): The OpenStack resource type to query for.
+        resource_name (str): The name of the OpenStack resource instance to
+            query for.
 
     Returns:
-        bool: Whether the expected value was found or not.
-    """
-
-    for i in range(0, retries):
-        sleep(6)
-        cmd = (". ~/openrc ; "
-               "openstack {} show \'{}\' "
-               "-f json".format(resource_type, resource_name))
-        output = run_on_container(cmd, 'utility', run_on_host)
-
-        try:
-            result = json.loads(output.stdout)
-        except ValueError as e:
-            result = str(e)
-            continue
-
-        if key in result:
-            if result[key] == expected_value:
-                return True
-            elif result[key].lower() == expected_value and case_insensitive:
-                return True
-            else:
-                continue
-        else:
-            print("\n Key not found: {}\n".format(key))
-            break
-
-    # Printing out logs if failed
-    print("\n===== Debug: get_expected_value logs =====")
-    # noinspection PyUnboundLocalVariable
-    print("\ncmd = {}".format(cmd))
-    # noinspection PyUnboundLocalVariable
-    print("\nOutput:\n {}".format(result))
-    print("\n===== End of get_expected_value logs =====")
-
-    return False
-
-
-def delete_instance(instance_name, run_on_host):
-    """Delete OpenStack instance
-
-    Args:
-        instance_name (str): OpenStack server identifier (name or id).
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-                                      action on.
+        uuid.UUID: ID of Openstack object instance.
 
     Raises:
-        AssertionError: If operation unsuccessful.
+        AssertionError: Resource type with given name not found!
     """
 
-    delete_it('server', instance_name, run_on_host)
-
-
-def create_instance(data, run_on_host):
-    """Create an instance from source (a glance image or a snapshot)
-
-    Args:
-        data (dict): Dictionary in the following format:
-                    data = {
-                        "instance_name": 'instance_name',
-                        "from_source": 'image',
-                        "source_name": 'image_name',
-                        "flavor": 'flavor',
-                        "network_name": 'network',
-                    }
-        run_on_host (testinfra.host.Host): A hostname where the command is being
-            executed.
-
-    Returns:
-        str: The id of the created resource
-
-    Raises:
-        AssertionError: If failed to create the resource
-
-    Example:
-    `openstack server create --image <image_id> flavor <flavor> \
-        --nic <net-id=network_id> server/instance_name` \
-    `openstack server create --snapshot <snapshot_id> flavor <flavor> \
-        --nic <net-id=network_id> server/instance_name`
-    """
-    source_id = get_id_by_name(data['from_source'],
-                               data['source_name'],
-                               run_on_host)
-    network_id = get_id_by_name('network', data['network_name'], run_on_host)
-
-    cmd = (". ~/openrc ; "
-           "openstack server create "
-           "-f json "
-           "--{} {} "
-           "--flavor {} "
-           "--nic net-id={} {}".format(data['from_source'],
-                                       source_id, data['flavor'],
-                                       network_id,
-                                       data['instance_name']))
-
-    output = run_on_container(cmd, 'utility', run_on_host)
-
-    try:
-        result = json.loads(output.stdout)
-    except ValueError:
-        result = output.stdout
-
-    assert type(result) is dict
-    assert 'id' in result
-
-    return result['id']
-
-
-def _resource_in_list(service_type,
-                      service_name,
-                      expected_resource,
-                      run_on_host,
-                      retries=10):
-    """Verify if a volume/server/image is existing
-
-    Args:
-        service_type (str): The OpenStack object type to query for.
-        service_name (str): The name of the OpenStack object to query for.
-        expected_resource (bool): Whether or not the resource is expected in the
-            list.
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-            action on.
-        retries (int): The maximum number of retry attempts.
-
-    Returns:
-        bool: Whether the expected resource was found or not.
-    """
-
-    sleep_timeout = 2
-
-    for i in range(0, retries):
-
-        res_id = get_id_by_name(service_type, service_name, run_on_host)
-
-        # Expecting that a resource IS in the list, for example after creating
-        # a resource, it is not shown in the list until several seconds later,
-        # retry every SLEEP seconds until reaching max retries (default = 10)
-        # to ensure the expected resource seen in the list.
-        if expected_resource:
-            if res_id:
-                return True
-            else:
-                sleep(sleep_timeout)
-
-        # Expecting that a resource is NOT in the list, for example after
-        # deleting a resource, it is STILL shown in the list until several
-        # seconds later, retry every SLEEP seconds until reaching max retries
-        # (default = 10) to ensure the resource is removed from the list
-        else:
-            if not res_id:
-                return True
-            else:
-                sleep(sleep_timeout)
-    return False
-
-
-def resource_is_in_the_list(service_type, service_name, run_on_host):
-    """ Verify if the resource is IN the list
-
-    Args:
-        service_type (str): The OpenStack object type to query for.
-        service_name (str): The name of the OpenStack object to query for.
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-            action on.
-
-    Returns:
-        bool: True if the resource is IN the list, False if the resource is not
-            in the list
-    """
-
-    return _resource_in_list(service_type, service_name, True, run_on_host)
-
-
-def resource_not_in_the_list(service_type, service_name, run_on_host):
-    """ Verify if the resource in NOT in the list
-
-    Args:
-        service_type (str): The OpenStack object type to query for.
-        service_name (str): The name of the OpenStack object to query for.
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-            action on.
-
-    Returns:
-        bool: True if the resource is NOT in the list, False if the resource is
-            in the list
-    """
-
-    return _resource_in_list(service_type, service_name, False, run_on_host)
-
-
-def stop_server_instance(instance_name, run_on_host):
-    """Stop an OpenStack server/instance
-
-    Args:
-        instance_name (str): The name of the OpenStack instance to be stopped.
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-            action on.
-
-    Raises:
-        AssertionError: If operation is unsuccessful.
-    """
-    instance_id = get_id_by_name('server', instance_name, run_on_host)
-
-    cmd = (". ~/openrc ; "
-           "openstack server stop {}".format(instance_id))
-
-    assert run_on_container(cmd, 'utility', run_on_host).rc == 0
-
-
-def create_snapshot_from_instance(snapshot_name, instance_name, run_on_host):
-    """Create snapshot on an instance
-
-    Args:
-        snapshot_name (str): The name of the OpenStack snapshot to be created.
-        instance_name (str): The name of the OpenStack instance from which the
-            snapshot is created.
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-            action on.
-
-    Returns:
-        str: The id of the created resource
-
-    Raises:
-        AssertionError: If failed to create the resource
-    """
-
-    instance_id = get_id_by_name('server', instance_name, run_on_host)
-    cmd = (". ~/openrc ; "
-           "openstack server image create "
-           "-f json "
-           "--name {} {}".format(snapshot_name, instance_id))
-
-    output = run_on_container(cmd, 'utility', run_on_host)
-
-    try:
-        result = json.loads(output.stdout)
-    except ValueError:
-        result = output.stdout
-
-    assert type(result) is dict
-    assert 'id' in result
-
-    return result['id']
-
-
-def delete_it(service_type, service_name, run_on_host, addl_flags=''):
-    """Delete an OpenStack object
-
-    Args:
-        service_type (str): The OpenStack object type to query for.
-        service_name (str): The name of the OpenStack object to query for.
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-            action on.
-        addl_flags (str): Additional flags to pass to the openstack command
-
-    Raises:
-        AssertionError: If operation is unsuccessful.
-    """
-
-    service_id = get_id_by_name(service_type, service_name, run_on_host)
-    cmd = (". ~/openrc ; "
-           "openstack {} delete "
-           "{} "
-           "{}".format(service_type, addl_flags, service_id))
-
-    assert run_on_container(cmd, 'utility', run_on_host).rc == 0
-    assert (resource_not_in_the_list(service_type, service_name, run_on_host))
-
-
-def create_floating_ip(network_name, run_on_host):
-    """Create floating IP on a network
-
-    Args:
-        network_name (str): The name of the OpenStack network object on which
-            the floating IP is created.
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-            action on.
-
-    Returns:
-        str: The newly created floating ip name
-
-    Raises:
-        AssertionError: If operation is unsuccessful.
-    """
-
-    network_id = get_id_by_name('network', network_name, run_on_host)
-    assert network_id is not None
-
-    cmd = (". ~/openrc ; "
-           "openstack floating ip create -f json {}".format(network_id))
-    output = run_on_container(cmd, 'utility', run_on_host)
-
-    assert (output.rc == 0)
-
-    try:
-        result = json.loads(output.stdout)
-    except ValueError:
-        result = output.stdout
-
-    assert type(result) is dict
-    key = 'floating_ip_address'
-    assert key in result.keys()
-
-    return result[key]
-
-
-# TODO: What is the specific use case for pinging from utility container?
-# TODO: Is no specific use case identified, then this helper is not needed.
-def ping_ip_from_utility_container(ip, run_on_host):
-    """Verify the IP address can be pinged from utility container on a host
-
-    Args:
-        ip (str): The string of the pinged IP address
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-            action on.
-
-    Returns:
-        bool: Whether the IP address can be pinged or not
-    """
-
-    cmd = "ping -c1 {}".format(ip)
-    if run_on_container(cmd, 'utility', run_on_host).rc == 0:
-        return True
+    __tracebackhide__ = True
+
+    resources = get_resources_by_name(run_on_host, resource_type, resource_name)
+    assert_msg = ("Resource type '{}' with given name '{}' was "
+                  "not found!".format(resource_type, resource_name))
+
+    if not resources:
+        raise AssertionError(assert_msg)
+    elif 'ID' in resources[0].keys():
+        return uuid.UUID(resources[0]['ID'])
     else:
-        return False
+        raise AssertionError(assert_msg)
 
 
-def run_on_container(command, container_type, run_on_host):
-    """Run the given command on the given container.
+def get_osa_version(branch):
+    """Get OpenStack version (code_name, major_version)
 
-    Args:
-        command (str): The bash command to run.
-        container_type (str): The container type to run the command on.
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-                                      wrapped command on.
-
-    Returns:
-        testinfra.CommandResult: Result of command execution.
-    """
-
-    pre_command = ("lxc-attach "
-                   "-n $(lxc-ls -1 | grep {} | head -n 1) "
-                   "-- bash -c".format(container_type))
-    cmd = "{} '{}'".format(pre_command, command)
-    return run_on_host.run(cmd)
-
-
-def run_on_swift(cmd, run_on_host):
-    """Run the given command on the swift container.
+    This data is based on the git branch of the test suite being executed
 
     Args:
-        cmd (str): Command
-        run_on_host (testinfra.Host): Testinfra host object to execute the
-                                      wrapped command on.
+        branch (str): The rpc-openstack branch to query for.
+
     Returns:
-        testinfra.CommandResult: Result of command execution.
+        tuple of (str, str): (code_name, major_version) OpenStack version.
+
+    Raises:
+        AssertionError: Unknown RPC-O release detected!
     """
 
-    command = (". ~/openrc ; "
-               ". /openstack/venvs/swift-*/bin/activate ; "
-               "{}".format(cmd))
-    return run_on_container(command, 'swift', run_on_host)
+    __tracebackhide__ = True
+
+    if branch in ['newton', 'newton-rc']:
+        return 'Newton', '14'
+    elif branch in ['pike', 'pike-rc']:
+        return 'Pike', '16'
+    elif branch in ['queens', 'queens-rc']:
+        return 'Queens', '17'
+    elif branch in ['rocky', 'rocky-rc']:
+        return 'Rocky', '18'
+    else:
+        raise AssertionError('Unknown RPC-O release detected!')
+
+
+def get_resource_by_id(run_on_host, resource_type, resource_id):
+    """Retrieve the OpenStack resource that matches the specified unique ID and
+    resource type.
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action upon.
+        resource_type (str): The OpenStack resource type to query for.
+        resource_id (uuid.UUID): The ID of the OpenStack resource instance to
+            query for.
+
+    Returns:
+        dict: An OpenStack resource for the given resource ID. {str:obj}
+
+    Raises:
+        RuntimeError: Failed to find resource of given type with specified ID or
+            somehow there are more than one resource with the same ID!
+    """
+
+    resources = get_resources_by_type(run_on_host, resource_type)
+
+    try:
+        matches = [x for x in resources if x['ID'] == resource_id]
+    except (KeyError, TypeError):
+        matches = []
+
+    if not matches:
+        raise RuntimeError("Resource type '{}' with ID '{}' was "
+                           "not found!".format(resource_type, str(resource_id)))
+    elif len(matches) > 1:
+        raise RuntimeError("Multiple resources type ID '{}' were "
+                           "found!".format(resource_type, str(resource_id)))
+
+    return matches[0]
+
+
+def get_resources_by_name(run_on_host, resource_type, resource_name):
+    """Retrieve a list of OpenStack resources that match the desired resource
+    name and type.
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action upon.
+        resource_type (str): The OpenStack resource type to query for.
+        resource_name (str): The name of the OpenStack resource instance to
+            query for.
+
+    Returns:
+        list: A list of OpenStack resources that match the given criteria.
+            [{str:obj}]
+    """
+
+    resources = get_resources_by_type(run_on_host, resource_type)
+
+    try:
+        matches = [x for x in resources if x['Name'] == resource_name]
+    except (KeyError, TypeError):
+        try:
+            matches = [x for x in resources if x['Display Name']
+                       == resource_name]
+        except (KeyError, TypeError):
+            matches = []
+
+    if not matches:
+        matches = []
+
+    return matches
+
+
+def get_resources_by_type(run_on_host, resource_type):
+    """Retrieve a list of resources by OpenStack resource type.
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action upon.
+        resource_type (str): The OpenStack resource type to query for.
+
+    Returns:
+        list: A list of OpenStack resources of the given type. [{str:obj}]
+    """
+
+    cmd = (". ~/openrc ; openstack {} list -f json".format(resource_type))
+    output = run_on_container(cmd, 'utility', run_on_host)
+
+    try:
+        result = json.loads(output.stdout)
+    except ValueError:
+        result = []
+
+    return result
 
 
 def parse_swift_recon(recon_out):
@@ -620,11 +608,12 @@ def parse_swift_recon(recon_out):
 
 def parse_swift_ring_builder(ring_builder_output):
     """Parse the supplied output into a dictionary of swift ring data.
+
     Args:
         ring_builder_output (str): The output from the swift-ring-builder
                                    command.
     Returns:
-        dict of {str: float}: Swift ring data. Empty dictionary if parse fails.
+        dict: Swift ring data. Empty dictionary if parse fails. {str: float}
 
     Example data:
         {'zones': 1.0,
@@ -646,3 +635,115 @@ def parse_swift_ring_builder(ring_builder_output):
             swift_data[k] = float(v)
 
     return swift_data
+
+
+def parse_table(ascii_table):
+    """Parse an OpenStack ascii table
+
+    Args:
+        ascii_table (str): OpenStack ascii table.
+
+    Returns:
+        list of str: Column headers from table.
+        list of str: Rows from table.
+    """
+
+    header = []
+    data = []
+    for line in filter(None, ascii_table.split('\n')):
+        if '-+-' in line:
+            continue
+        if not header:
+            header = list(filter(lambda x: x != '|', line.split()))
+            continue
+        data_row = []
+        splitted_line = list(filter(lambda x: x != '|', line.split()))
+        for i in range(len(splitted_line)):
+            data_row.append(splitted_line[i])
+        while len(data_row) < len(header):
+            data_row.append('')
+        data.append(data_row)
+    return header, data
+
+
+# TODO: What is the specific use case for pinging from utility container?
+# TODO: Is no specific use case identified, then this helper is not needed.
+def ping_ip_from_utility_container(ip, run_on_host):
+    """Verify the IP address can be pinged from utility container on a host
+
+    Args:
+        ip (str): The string of the pinged IP address
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action on.
+
+    Returns:
+        bool: Whether the IP address can be pinged or not
+    """
+
+    cmd = "ping -c1 {}".format(ip)
+    if run_on_container(run_on_host, cmd, 'utility').rc == 0:
+        return True
+    else:
+        return False
+
+
+def run_on_container(run_on_host, command, container_type):
+    """Run the given command on the given container.
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            wrapped command on.
+        command (str): The bash command to run.
+        container_type (str): The container type to run the command on.
+
+    Returns:
+        testinfra.CommandResult: Result of command execution.
+    """
+
+    pre_command = ("lxc-attach "
+                   "-n $(lxc-ls -1 | grep {} | head -n 1) "
+                   "-- bash -c".format(container_type))
+    cmd = "{} '{}'".format(pre_command, command)
+
+    return run_on_host.run(cmd)
+
+
+def run_on_swift(run_on_host, cmd):
+    """Run the given command on the swift container.
+
+    Args:
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            wrapped command on.
+        cmd (str): Command
+
+    Returns:
+        testinfra.CommandResult: Result of command execution.
+    """
+
+    command = (". ~/openrc ; "
+               ". /openstack/venvs/swift-*/bin/activate ; "
+               "{}".format(cmd))
+
+    return run_on_container(run_on_host, command, 'swift')
+
+
+def stop_server_instance(instance_id, run_on_host):
+    """Stop an OpenStack server/instance
+
+    Args:
+        instance_id (uuid.UUID): The OpenStack resource ID for the instance
+            to be stopped.
+        run_on_host (testinfra.Host): Testinfra host object to execute the
+            action on.
+
+    Raises:
+        AssertionError: Failed to stop instance!
+    """
+
+    __tracebackhide__ = True
+
+    cmd = (". ~/openrc ; openstack server stop {}".format(instance_id))
+    assert_msg = ("Failed to stop instance with resource"
+                  "ID '{}'!".format(instance_id))
+
+    assert run_on_container(run_on_host, cmd, 'utility').rc == 0, assert_msg

--- a/tests/helpers/test_delete_instance.py
+++ b/tests/helpers/test_delete_instance.py
@@ -17,7 +17,7 @@ def test_successful_deletion(mocker):
     """Verify delete_instance returns None when server instance is
     successfully deleted."""
 
-    mocker.patch('pytest_rpc.helpers.delete_it', return_value=True)
+    mocker.patch('pytest_rpc.helpers._delete_it', return_value=True)
 
     assert not pytest_rpc.helpers.delete_instance('myserver', 'host')
 
@@ -28,7 +28,7 @@ def test_failed_deletion(mocker):
     """Verify delete_instance raises and AssertionError when server instance
     has failed to be successfully deleted."""
 
-    mocker.patch('pytest_rpc.helpers.delete_it', side_effect=AssertionError())
+    mocker.patch('pytest_rpc.helpers._delete_it', side_effect=AssertionError())
 
     with pytest.raises(AssertionError):
         pytest_rpc.helpers.delete_instance('myserver', 'host')

--- a/tests/helpers/test_delete_it.py
+++ b/tests/helpers/test_delete_it.py
@@ -5,11 +5,11 @@ import testinfra.backend.base
 import testinfra.host
 import json
 
-"""Test cases for the 'delete_it' helper function."""
+"""Test cases for the '_delete_it' helper function."""
 
 
 def test_success(mocker):
-    """Verify delete_it completes without raising an error and returns None
+    """Verify _delete_it completes without raising an error and returns None
     when the OpenStack command returns an exit code of '0'.
 
     relies on mocked objects from testinfra
@@ -26,11 +26,11 @@ def test_success(mocker):
     cr1.rc = 0
     cr1.stdout = json.dumps(server)
 
-    assert not pytest_rpc.helpers.delete_it('server', 'myserver', myhost)
+    assert not pytest_rpc.helpers._delete_it('server', 'myserver', myhost)
 
 
 def test_failure(mocker):
-    """Verify delete_it raises an error when the OpenStack command returns an
+    """Verify _delete_it raises an error when the OpenStack command returns an
     exit code of '2'.
 
     relies on mocked objects from testinfra
@@ -46,11 +46,11 @@ def test_failure(mocker):
     cr1.stdout = ''
 
     with pytest.raises(AssertionError):
-        pytest_rpc.helpers.delete_it('server', 'myserver', myhost)
+        pytest_rpc.helpers._delete_it('server', 'myserver', myhost)
 
 
 def test_resource_not_deleted(mocker):
-    """Verify delete_it raises an error when the OpenStack resource is not
+    """Verify _delete_it raises an error when the OpenStack resource is not
     deleted.
 
     relies on mocked objects from testinfra
@@ -67,4 +67,4 @@ def test_resource_not_deleted(mocker):
     cr1.stdout = json.dumps(server)
 
     with pytest.raises(AssertionError):
-        pytest_rpc.helpers.delete_it('server', 'myserver', myhost)
+        pytest_rpc.helpers._delete_it('server', 'myserver', myhost)

--- a/tests/helpers/test_delete_volume.py
+++ b/tests/helpers/test_delete_volume.py
@@ -17,7 +17,7 @@ def test_successful_deletion(mocker):
     """Verify delete_volume returns None when OpenStack volume has been
     successfully deleted."""
 
-    mocker.patch('pytest_rpc.helpers.delete_it', return_value=True)
+    mocker.patch('pytest_rpc.helpers._delete_it', return_value=True)
 
     assert not pytest_rpc.helpers.delete_volume('myvolume', 'host')
 
@@ -28,7 +28,7 @@ def test_failed_deletion(mocker):
     """Verify delete_volume raises an AssertionError when OpenStack volume has
     failed to successfully be deleted."""
 
-    mocker.patch('pytest_rpc.helpers.delete_it', side_effect=AssertionError())
+    mocker.patch('pytest_rpc.helpers._delete_it', side_effect=AssertionError())
 
     with pytest.raises(AssertionError):
         pytest_rpc.helpers.delete_volume('myvolume', 'host')


### PR DESCRIPTION
This refactor is intended to make the interface of helper functions more
predictable. CRUD operations that create should always return a UUID and
RUD operations should except only IDs.

This PR was posted as reference for a deeper conversation on how to re-write the helpers.