### PR TITLE
ASC-1627 Add get_cinder_major_version helper

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
+packaging~=18.0
 pip<10.0.0
 pytest~=3.6

--- a/pytest_rpc/helpers.py
+++ b/pytest_rpc/helpers.py
@@ -9,6 +9,7 @@ from warnings import warn
 from pprint import pformat
 from platform import system
 from subprocess import call
+from packaging.version import Version, InvalidVersion
 
 
 # ==============================================================================
@@ -252,3 +253,26 @@ def parse_swift_ring_builder(ring_builder_output):
             swift_data[k] = float(v)
 
     return swift_data
+
+
+def get_cinder_major_version(run_on_host):
+    """ Retrieve cinder version number from utility container
+
+    Args:
+        run_on_host (testinfra.host.Host): Testinfra host fixture
+
+    Return:
+        int: cinder major version, -1 if lookup fails
+
+    """
+
+    cmd = '. openrc ; cinder --version'
+    result = run_on_container(cmd, 'utility', run_on_host)
+
+    try:
+        v = Version(result.stdout)
+        major = v.release[0]
+    except (InvalidVersion):
+        major = -1
+
+    return major

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ bumpversion
 configparser
 flake8
 ipython
+packaging
 paramiko
 pytest
 pytest-cov

--- a/tests/helpers/test_get_cinder_major_version.py
+++ b/tests/helpers/test_get_cinder_major_version.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+import pytest_rpc.helpers
+import testinfra.backend.base
+import testinfra.host
+
+"""Test cases for the 'get_cinder_major_version' helper function."""
+
+
+def test_valid_version(mocker):
+    """Verify get_cinder_major_version returns the major version when the
+    cinder version is set to a valid semantic version.
+
+    relies on mocked objects from testinfra
+    """
+
+    fake_backend = mocker.Mock(spec=testinfra.backend.base.BaseBackend)
+    myhost = testinfra.host.Host(fake_backend)
+    cr = mocker.Mock(spec=testinfra.backend.base.CommandResult)
+
+    cr.rc = 0
+    cr.stdout = '3.2.1'
+    mocker.patch('testinfra.host.Host.run', return_value=cr)
+
+    assert pytest_rpc.helpers.get_cinder_major_version(myhost) == 3
+
+
+def test_invalid_version(mocker):
+    """Verify get_cinder_major_version returns -1 when the cinder version is
+    set to an invalid semantic version.
+
+    relies on mocked objects from testinfra
+    """
+
+    fake_backend = mocker.Mock(spec=testinfra.backend.base.BaseBackend)
+    myhost = testinfra.host.Host(fake_backend)
+    cr = mocker.Mock(spec=testinfra.backend.base.CommandResult)
+
+    cr.rc = 0
+    cr.stdout = 'foobar'
+    mocker.patch('testinfra.host.Host.run', return_value=cr)
+
+    assert pytest_rpc.helpers.get_cinder_major_version(myhost) == -1
+
+
+def test_error(mocker):
+    """Verify get_cinder_major_version returns -1 when the query for the
+    cinder version results in an error.
+
+    relies on mocked objects from testinfra
+    """
+
+    fake_backend = mocker.Mock(spec=testinfra.backend.base.BaseBackend)
+    myhost = testinfra.host.Host(fake_backend)
+    cr = mocker.Mock(spec=testinfra.backend.base.CommandResult)
+
+    cr.rc = 1
+    cr.stdout = ''
+    mocker.patch('testinfra.host.Host.run', return_value=cr)
+
+    assert pytest_rpc.helpers.get_cinder_major_version(myhost) == -1


### PR DESCRIPTION
This commit adds a helper method called `get_cinder_major_version` that
returns the major version of cinder as inspected on the utility
container of an RPC-O installation.  Supporting tests are included as
well.

This helper makes use of the [packaging](https://packaging.pypa.io/en/latest/)
python module.  So, the requirements and constraints files are updated
with this dependency.