### PR TITLE
ASC-1661 Add packaging to setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 python_requirements = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
 requirements = ['configparser',
-                'packaging',
+                'packaging~=18.0',
                 'paramiko',
                 'pytest~=3.6',
                 'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 python_requirements = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
 requirements = ['configparser',
+                'packaging',
                 'paramiko',
                 'pytest~=3.6',
                 'setuptools',


### PR DESCRIPTION
This commit adds `packaging` to the requirements list in setup.py.  This
addition was forgotten in the commit for ASC-1627